### PR TITLE
install.js: only download Sauce-Connect if missing

### DIFF
--- a/install.js
+++ b/install.js
@@ -7,14 +7,20 @@ var request = require('request')
 var unzip = require('unzip')
 
 var SAUCE_CONNECT_URL = 'http://saucelabs.com/downloads/Sauce-Connect-latest.zip'
+var jarName = 'Sauce-Connect.jar'
+var jarPath = path.join(__dirname, 'thirdparty', jarName)
 
-console.log("Downloading Sauce-Connect.jar from SauceLabs...")
-request(SAUCE_CONNECT_URL)
+if (fs.existsSync(jarPath)) {
+  console.log("Sauce Connect already downloaded to "+jarPath)
+} else {
+  console.log("Downloading Sauce-Connect.jar from SauceLabs...")
+  request(SAUCE_CONNECT_URL)
   .pipe(unzip.Parse())
   .on('entry', function(entry) {
-    if (entry.path === 'Sauce-Connect.jar') {
-      entry.pipe(fs.createWriteStream(path.join(__dirname, 'thirdparty', entry.path)))
+    if (entry.path === jarName) {
+      entry.pipe(fs.createWriteStream(jarPath))
     } else {
       entry.autodrain()
     }
   })
+}


### PR DESCRIPTION
massively speeds up "npm install" in strider directory.
